### PR TITLE
Add `PostcardAssetLoader` as `OutputLoader` to `PostcardAssetSaver`

### DIFF
--- a/src/postcard.rs
+++ b/src/postcard.rs
@@ -102,10 +102,10 @@ impl<A> Default for PostcardAssetSaver<A> {
     }
 }
 
-impl<A: Asset + Serialize> AssetSaver for PostcardAssetSaver<A> {
+impl<A: Asset + for<'de> Deserialize<'de> + Serialize> AssetSaver for PostcardAssetSaver<A> {
     type Asset = A;
     type Settings = ();
-    type OutputLoader = ();
+    type OutputLoader = PostcardAssetLoader<A>;
     type Error = PostcardAssetError;
 
     fn save<'a>(


### PR DESCRIPTION
This makes it so that the `.meta` files generated by `PostcardAssetSaver` use `PostcardAssetLoader` as a loader, which allows the asset to load with asset preprocessing

## Breaking changes

The type parameter of `PostcardAssetSaver` must implement `Deserialize`. This is only a breaking change if a release is made before this pr is merged, since `PostcardAssetSaver` was private in the last release (0.10.0 at the time of writing).