### PR TITLE
Upgrade to Bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ csv = ["dep:csv"]
 postcard = ["dep:postcard"]
 
 [dependencies]
-bevy = { version = "0.15.0", default-features = false, features = ["bevy_asset"] }
+bevy = { version = "0.16.0", default-features = false, features = ["bevy_asset"] }
 serde_toml = { version = "0.8", package = "toml", optional = true }
 serde_ron = { version = "0.8", package = "ron", optional = true }
 serde_yaml = { version = "0.9", optional = true }
@@ -37,7 +37,7 @@ anyhow = { version = "1" }
 postcard = {version = "1.0", features = ["use-std"], optional = true}
 
 [dev-dependencies]
-bevy = { version = "0.15.0" }
+bevy = { version = "0.16.0" }
 serde = { version = "1" }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
It doesn't seem like any changes are necessary. Tested all the examples.