### PR TITLE
Bump toml crate to v1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ cbor = ["dep:ciborium"]
 bevy_app = { version = "0.18.0", default-features = false }
 bevy_asset = { version = "0.18.0", default-features = false }
 bevy_reflect = { version = "0.18.0", default-features = false }
-serde_toml = { version = "0.9", package = "toml", optional = true }
+serde_toml = { version = "1.1.2", package = "toml", optional = true }
 serde_ron = { version = "0.11", package = "ron", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 serde_json = { version = "1", optional = true }


### PR DESCRIPTION
- MSRV goes to 1.85 (which is compatible with Bevy's MSRV)
- internally, should be *nearly* transparent
  - the breaking change has to do with TOML v1.1 time handling (which v0.9 supports, but deserializes missing (nano)seconds as 0)
  - some pretty important bugfixes like https://github.com/toml-rs/toml/pull/1130, which prevents a possible callstack overflow